### PR TITLE
Add support for conntrack states in OVS flow

### DIFF
--- a/odp/flow.go
+++ b/odp/flow.go
@@ -810,6 +810,7 @@ var flowKeyParsers = FlowKeyParsers{
 	OVS_KEY_ATTR_DP_HASH:   blobFlowKeyParser(4, nil),
 	OVS_KEY_ATTR_TCP_FLAGS: blobFlowKeyParser(2, nil),
 	OVS_KEY_ATTR_RECIRC_ID: blobFlowKeyParser(4, nil),
+	OVS_KEY_ATTR_CT_STATE:  blobFlowKeyParser(4, nil),
 
 	OVS_KEY_ATTR_TUNNEL: FlowKeyParser{
 		parse:      parseTunnelFlowKey,

--- a/odp/syscall.go
+++ b/odp/syscall.go
@@ -164,6 +164,11 @@ const ( // ovs_key_attr
 	OVS_KEY_ATTR_TCP_FLAGS = 18
 	OVS_KEY_ATTR_DP_HASH   = 19
 	OVS_KEY_ATTR_RECIRC_ID = 20
+	OVS_KEY_ATTR_MPLS      = 21
+	OVS_KEY_ATTR_CT_STATE  = 22
+	OVS_KEY_ATTR_CT_ZONE   = 23
+	OVS_KEY_ATTR_CT_MARK   = 24
+	OVS_KEY_ATTR_CT_LABELS = 25
 )
 
 const ( // ovs_tunnel_key_attr


### PR DESCRIPTION
Linux 4.3.0 introduces support for conntrack states in OVS flow. It
breaks compatibility with weave causing errors and lack of connectivity
between containers:

Error while listening on ODP datapath: unknown flow key type 22 (value
[0 0 0 0])

Missing flow key is OVS_KEY_ATTR_CT_STATE, which in fact is 32-bit
value representing connection state pulled from conntrack. More details
are available at lkml commit topic https://lkml.org/lkml/2015/7/30/661

Although this patch solved problems for me, I'm not 100% convinced
whether this is proper solution, as spent only little time on research.
It may be treated as reminder about upcoming changes though.