### PR TITLE
Cope with (apparent) Linux 4.3 changes.

### DIFF
--- a/odp/netlink.go
+++ b/odp/netlink.go
@@ -527,10 +527,13 @@ func (attrs Attrs) GetOrderedAttrs(typ uint16) ([]Attr, error) {
 	if val == nil {
 		return nil, err
 	}
+	return ParseOrderedAttrs(val)
+}
 
-	parser := NlMsgParser{data: val, pos: 0}
+func ParseOrderedAttrs(data []byte) ([]Attr, error) {
+	parser := NlMsgParser{data: data, pos: 0}
 	res := make([]Attr, 0)
-	err = parser.parseAttrs(func(typ uint16, val []byte) {
+	err := parser.parseAttrs(func(typ uint16, val []byte) {
 		res = append(res, Attr{typ, val})
 	})
 


### PR DESCRIPTION
- accept more than one attribute in a OVS_ACTION_ATTR_SET
- accept attributes other than OVS_KEY_ATTR_TUNNEL
- store non-tunnel attributes so they can be printed out later
- process attributes in order, in case that makes them easier to interpret.

This change prevents the abrupt failure seen in https://github.com/weaveworks/weave/issues/1854, although I suspect there is a higher-level error somewhere because the data I seem to be getting does not make sense.