### PR TITLE
Handle fixed genl reply messages

### DIFF
--- a/odp/datapath.go
+++ b/odp/datapath.go
@@ -13,8 +13,8 @@ type datapathInfo struct {
 	name    string
 }
 
-func (dpif *Dpif) parseDatapathInfo(msg *NlMsgParser) (res datapathInfo, err error) {
-	_, ovshdr, err := dpif.checkNlMsgHeaders(msg, DATAPATH, OVS_DP_CMD_NEW)
+func (dpif *Dpif) parseDatapathInfo(msg *NlMsgParser, cmd int) (res datapathInfo, err error) {
+	_, ovshdr, err := dpif.checkNlMsgHeaders(msg, DATAPATH, cmd)
 	if err != nil {
 		return
 	}
@@ -58,7 +58,7 @@ func (dpif *Dpif) CreateDatapath(name string) (DatapathHandle, error) {
 		return DatapathHandle{}, err
 	}
 
-	dpi, err := dpif.parseDatapathInfo(resp)
+	dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_NEW)
 	if err != nil {
 		return DatapathHandle{}, err
 	}
@@ -81,7 +81,7 @@ func (dpif *Dpif) LookupDatapath(name string) (DatapathHandle, error) {
 		return DatapathHandle{}, err
 	}
 
-	dpi, err := dpif.parseDatapathInfo(resp)
+	dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_GET)
 	if err != nil {
 		return DatapathHandle{}, err
 	}
@@ -104,7 +104,7 @@ func (dpif *Dpif) LookupDatapathByID(ifindex DatapathID) (Datapath, error) {
 		return Datapath{}, err
 	}
 
-	dpi, err := dpif.parseDatapathInfo(resp)
+	dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_GET)
 	if err != nil {
 		return Datapath{}, err
 	}
@@ -127,7 +127,7 @@ func (dpif *Dpif) EnumerateDatapaths() (map[string]DatapathHandle, error) {
 	req.putOvsHeader(0)
 
 	consumer := func(resp *NlMsgParser) error {
-		dpi, err := dpif.parseDatapathInfo(resp)
+		dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_GET)
 		if err != nil {
 			return err
 		}

--- a/odp/dpif.go
+++ b/odp/dpif.go
@@ -169,7 +169,7 @@ func (dpif *Dpif) checkNlMsgHeaders(msg *NlMsgParser, family int, cmd int) (*Gen
 	case FLOW:
 		genlhdr, err = msg.CheckGenlMsghdr(cmd, OVS_FLOW_CMD_NEW)
 	default:
-		genlhdr, err = msg.CheckGenlMsghdr(cmd)
+		genlhdr, err = msg.CheckGenlMsghdr(cmd, -1)
 	}
 	if err != nil {
 		return nil, nil, err

--- a/odp/dpif_test.go
+++ b/odp/dpif_test.go
@@ -424,11 +424,11 @@ type vportTestConsumer struct {
 	ch chan error
 }
 
-func (vportTestConsumer) VportCreated(ifindex int32, vport Vport) error {
+func (vportTestConsumer) VportCreated(ifindex DatapathID, vport Vport) error {
 	return nil
 }
 
-func (vportTestConsumer) VportDeleted(ifindex int32, vport Vport) error {
+func (vportTestConsumer) VportDeleted(ifindex DatapathID, vport Vport) error {
 	return nil
 }
 

--- a/odp/flow.go
+++ b/odp/flow.go
@@ -840,7 +840,7 @@ func (key TunnelFlowKey) Ignored() bool {
 		AllBytes(m.Ipv4Dst[:], 0) &&
 		m.Tos == 0 &&
 		m.Ttl == 0 &&
-		!m.Csum && !m.Csum &&
+		!m.Csum &&
 		m.TpSrc == 0 && m.TpDst == 0
 }
 
@@ -1236,8 +1236,8 @@ func (a FlowSpec) Equals(b FlowSpec) bool {
 	return true
 }
 
-func (dp DatapathHandle) parseFlowMsg(msg *NlMsgParser) (Attrs, error) {
-	if err := dp.checkNlMsgHeaders(msg, FLOW, OVS_FLOW_CMD_NEW); err != nil {
+func (dp DatapathHandle) parseFlowMsg(msg *NlMsgParser, cmd int) (Attrs, error) {
+	if err := dp.checkNlMsgHeaders(msg, FLOW, cmd); err != nil {
 		return nil, err
 	}
 
@@ -1375,7 +1375,7 @@ func (dp DatapathHandle) EnumerateFlows() ([]FlowInfo, error) {
 	req.putOvsHeader(dp.ifindex)
 
 	consumer := func(resp *NlMsgParser) error {
-		attrs, err := dp.parseFlowMsg(resp)
+		attrs, err := dp.parseFlowMsg(resp, OVS_FLOW_CMD_GET)
 		if err != nil {
 			return err
 		}

--- a/odp/genetlink.go
+++ b/odp/genetlink.go
@@ -18,22 +18,16 @@ func (nlmsg *NlMsgBuilder) PutGenlMsghdr(cmd uint8, version uint8) *GenlMsghdr {
 	return res
 }
 
-func (nlmsg *NlMsgParser) CheckGenlMsghdr(cmds ...int) (*GenlMsghdr, error) {
+func (nlmsg *NlMsgParser) CheckGenlMsghdr(cmd int, fallbackCmd int) (*GenlMsghdr, error) {
 	pos, err := nlmsg.AlignAdvance(syscall.NLMSG_ALIGNTO, SizeofGenlMsghdr)
 	if err != nil {
 		return nil, err
 	}
 
 	gh := genlMsghdrAt(nlmsg.data, pos)
-	cmdMatch := false
-	for _, cmd := range cmds {
-		if cmd < 0 || gh.Cmd == uint8(cmd) {
-			cmdMatch = true
-			break
-		}
-	}
-	if !cmdMatch {
-		return nil, fmt.Errorf("generic netlink response has wrong cmd (got %d, expected either of %v)", gh.Cmd, cmds)
+	if cmd >= 0 && gh.Cmd != uint8(cmd) && (fallbackCmd < 0 || gh.Cmd != uint8(fallbackCmd)) {
+		return nil, fmt.Errorf("generic netlink response has wrong cmd (got %d, expected %d (or fallback: %d))",
+			gh.Cmd, cmd, fallbackCmd)
 	}
 
 	// Deliberately ignore the version field in the genl header.
@@ -64,10 +58,9 @@ func (s *NetlinkSocket) LookupGenlFamily(name string) (family GenlFamily, err er
 		return
 	}
 
-	// TODO: It should have been CTRL_CMD_GETFAMILY, though it would be a huge breaking change for
-	//       userspace apps. If kernel folks would decide to correct it by any chance, we will
-	//       correct the next line as well.
-	_, err = resp.CheckGenlMsghdr(CTRL_CMD_NEWFAMILY)
+	// For now response command is always CTRL_CMD_NEWFAMILY, though it should have
+	// been CTRL_CMD_GETFAMILY. For stability forever, we utilize fallbacking here.
+	_, err = resp.CheckGenlMsghdr(CTRL_CMD_GETFAMILY, CTRL_CMD_NEWFAMILY)
 	if err != nil {
 		return
 	}

--- a/odp/vport.go
+++ b/odp/vport.go
@@ -242,7 +242,7 @@ func lookupVport(dpif *Dpif, dpifindex DatapathID, name string) (DatapathID, Vpo
 		return 0, Vport{}, err
 	}
 
-	_, ovshdr, err := dpif.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_NEW)
+	_, ovshdr, err := dpif.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_GET)
 	if err != nil {
 		return 0, Vport{}, err
 	}
@@ -276,7 +276,7 @@ func (dp DatapathHandle) LookupVport(id VportID) (Vport, error) {
 		return Vport{}, err
 	}
 
-	err = dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_NEW)
+	err = dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_GET)
 	if err != nil {
 		return Vport{}, err
 	}
@@ -311,7 +311,7 @@ func (dp DatapathHandle) EnumerateVports() ([]Vport, error) {
 
 	var res []Vport
 	consumer := func(resp *NlMsgParser) error {
-		err := dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_NEW)
+		err := dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_GET)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Recently, a patch for Linux kernel net-next tree (http://patchwork.ozlabs.org/patch/975343/) was accepted and some incorrectly set command in genl reply messages are now fixed. This PR intends to make go-odp work for both, first trying with the correct cmd and fallback to incorrect one where appropriate. Otherwise, weave will suffer from fastdpimpl init failure in newer kernel environment.

If this is okay, we might need to update vendered go-odp under weave.git as it does from master branch. Please review, thanks.